### PR TITLE
Fix wrong pal in part 16006 when starting at 16005

### DIFF
--- a/resource.cpp
+++ b/resource.cpp
@@ -357,6 +357,7 @@ void Resource::invalidateAll() {
 		_memList[i].status = STATUS_NULL;
 	}
 	_scriptCurPtr = _memPtrStart;
+	_vid->_currentPal = 0xFF;
 }
 
 static const uint8_t *getSoundsList3DO(int num) {

--- a/script.cpp
+++ b/script.cpp
@@ -814,7 +814,7 @@ void Script::fixUpPalette_changeScreen(int part, int screen) {
 		break;
 	case 16006:
 		if (screen == 0x4A) { // bitmap resources #144, #145
-			pal = 1;
+			pal = 2;
 		}
 		break;
 	}


### PR DESCRIPTION
I played with the DOS version.
When starting the game from the beginning or from part 16005, when we arrive in part 16006, the palette seems wrong:
<img width="752" alt="Capture d’écran 2021-12-28 à 15 32 24" src="https://user-images.githubusercontent.com/643384/147590825-f3149e20-d7f2-4fcb-a177-6384fc20b146.png">
But if we start directly from part 16006, the palette is good.

This pull request fix this, but I didn't test the other versions (Amiga, Atari ST, 3D0, etc.).

PS: By the way, thank you for this awesome project
