### PR TITLE
Add support for 15th Anniversary Edition without remastered music

### DIFF
--- a/resource_nth.cpp
+++ b/resource_nth.cpp
@@ -175,12 +175,19 @@ struct Resource15th: ResourceNth {
 
 	virtual const char *getMusicName(int num) {
 		const char *path = 0;
+		File f;
 		switch (num) {
 		case 7:
 			path = "Music/AW/RmSnd/Intro2004.wav";
+			if (!f.open(path)) {
+				path = "Music/AW/Intro2004.wav";
+			}
 			break;
 		case 138:
 			path = "Music/AW/RmSnd/End2004.wav";
+			if (!f.open(path)) {
+				path = "Music/AW/End2004.wav";
+			}
 			break;
 		}
 		return path;


### PR DESCRIPTION
Version 1.1B of the 15th Anniversary Edition (demo version) doesn't contain remastered audio. That's already handled for the sound effects. This change handles missing remastered music by using the original music.

Would it make sense to make a command line option to use remastered or original audio in Anniversary Editions ? (And maybe an option to set difficulty ?)

P.S. Are you aware that the music in DOS/Amiga versions is played slower than it should ? In the ending song, the last seconds are cut off before being played (it doesn't get cut off when playing the game in DOSBox). I don't know what's the problem, but when I used constant `7500` instead of `7050` when calculating delay in `sfxplayer.cpp`, the music seemed to play with the correct speed.