### PR TITLE
Add sound looping in Win3.1/15th/20th versions

### DIFF
--- a/mixer.cpp
+++ b/mixer.cpp
@@ -109,7 +109,7 @@ struct Mixer_impl {
 				playSound(channel, volume, chunk, loops);
 				return;
 			}
-                }
+		}
 		const uint32_t size = READ_LE_UINT32(data + 4) + 8;
 		SDL_RWops *rw = SDL_RWFromConstMem(data, size);
 		Mix_Chunk *chunk = Mix_LoadWAV_RW(rw, 1);
@@ -219,10 +219,10 @@ void Mixer::playSoundRaw(uint8_t channel, const uint8_t *data, uint16_t freq, ui
 	}
 }
 
-void Mixer::playSoundWav(uint8_t channel, const uint8_t *data, uint16_t freq, uint8_t volume) {
-	debug(DBG_SND, "Mixer::playSoundWav(%d, %d)", channel, volume);
+void Mixer::playSoundWav(uint8_t channel, const uint8_t *data, uint16_t freq, uint8_t volume, uint8_t loop) {
+	debug(DBG_SND, "Mixer::playSoundWav(%d, %d, %d)", channel, volume, loop);
 	if (_impl) {
-		return _impl->playSoundWav(channel, data, freq, volume);
+		return _impl->playSoundWav(channel, data, freq, volume, (loop != 0) ? -1 : 0);
 	}
 }
 

--- a/mixer.h
+++ b/mixer.h
@@ -24,7 +24,7 @@ struct Mixer {
 	void update();
 
 	void playSoundRaw(uint8_t channel, const uint8_t *data, uint16_t freq, uint8_t volume);
-	void playSoundWav(uint8_t channel, const uint8_t *data, uint16_t freq, uint8_t volume);
+	void playSoundWav(uint8_t channel, const uint8_t *data, uint16_t freq, uint8_t volume, uint8_t loop);
 	void playSoundAiff(uint8_t channel, const uint8_t *data, uint8_t volume);
 	void stopSound(uint8_t channel);
 	void setChannelVolume(uint8_t channel, uint8_t volume);

--- a/script.cpp
+++ b/script.cpp
@@ -715,6 +715,23 @@ void Script::inp_handleSpecialKeys() {
 	}
 }
 
+static uint8_t getWavLooping(uint16_t resNum) {
+	switch (resNum) {
+	case 1:
+	case 3:
+	case 8:
+	case 16:
+	case 89:
+	case 97:
+	case 102:
+	case 104:
+	case 106:
+	case 132:
+	case 139: return 1;
+	}
+	return 0;
+}
+
 void Script::snd_playSound(uint16_t resNum, uint8_t freq, uint8_t vol, uint8_t channel) {
 	debug(DBG_SND, "snd_playSound(0x%X, %d, %d, %d)", resNum, freq, vol, channel);
 	if (vol == 0) {
@@ -728,7 +745,7 @@ void Script::snd_playSound(uint16_t resNum, uint8_t freq, uint8_t vol, uint8_t c
 	case Resource::DT_15TH_EDITION: {
 			uint8_t *buf = _res->loadWav(resNum);
 			if (buf) {
-				_mix->playSoundWav(channel & 3, buf, _freqTable[freq], vol);
+				_mix->playSoundWav(channel & 3, buf, _freqTable[freq], vol, getWavLooping(resNum));
 			}
 		}
 		break;
@@ -737,7 +754,7 @@ void Script::snd_playSound(uint16_t resNum, uint8_t freq, uint8_t vol, uint8_t c
 			// ignore sample rate specified by the script, use .wav header value
 			uint8_t *buf = _res->loadWav(resNum);
 			if (buf) {
-				_mix->playSoundWav(channel & 3, buf, 0, vol);
+				_mix->playSoundWav(channel & 3, buf, 0, vol, getWavLooping(resNum));
 			}
 		}
 		break;


### PR DESCRIPTION
The 15th/20th Anniversary Editions have a list of sounds (hardcoded in the executable) which should be playing in loop.
This change adds this list and loops sounds based on it in 15th/20th versions and also in Win3.1 version even though it doesn't loop sounds.