### PR TITLE
Add command-line option to select original or remastered audio

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,9 @@ directory. This can be changed with command line switches.
     --fullscreen      Fullscreen display (stretched)
     --fullscreen-ar   Fullscreen display (16:10 aspect ratio)
     --ega-palette     Use EGA palette with DOS version
+    --demo3-joy       Use inputs from 'demo3.joy' (DOS demo)
+    --difficulty=DIFF Difficulty (easy,normal,hard)
+    --audio=AUDIO     Audio (original,remastered)
 ```
 
 In game hotkeys :

--- a/main.cpp
+++ b/main.cpp
@@ -27,6 +27,7 @@ static const char *USAGE =
 	"  --ega-palette     Use EGA palette with DOS version\n"
 	"  --demo3-joy       Use inputs from 'demo3.joy' (DOS demo)\n"
 	"  --difficulty=DIFF Difficulty (easy,normal,hard)\n"
+	"  --audio=AUDIO     Audio (original,remastered)\n"
 	;
 
 static const struct {
@@ -65,6 +66,7 @@ bool Graphics::_is1991 = false;
 bool Graphics::_use555 = false;
 bool Video::_useEGA = false;
 Difficulty Script::_difficulty = DIFFICULTY_NORMAL;
+bool Script::_useRemasteredAudio = true;
 
 static Graphics *createGraphics(int type) {
 	switch (type) {
@@ -149,6 +151,7 @@ int main(int argc, char *argv[]) {
 			{ "ega-palette", no_argument,    0, 'e' },
 			{ "demo3-joy",  no_argument,     0, 'j' },
 			{ "difficulty", required_argument, 0, 'i' },
+			{ "audio",    required_argument, 0, 'u' },
 			{ "help",       no_argument,     0, 'h' },
 			{ 0, 0, 0, 0 }
 		};
@@ -208,6 +211,13 @@ int main(int argc, char *argv[]) {
 				}
 			}
 			break;
+		case 'u':
+			if (strcmp(optarg, "remastered") == 0) {
+				Script::_useRemasteredAudio = true;
+			} else if (strcmp(optarg, "original") == 0) {
+				Script::_useRemasteredAudio = false;
+			}
+			break;
 		case 'h':
 			// fall-through
 		default:
@@ -238,6 +248,13 @@ int main(int argc, char *argv[]) {
 		case DIFFICULTY_HARD:
 			debug(DBG_INFO, "Using hard difficulty");
 			break;
+		}
+	}
+	if (e->_res.getDataType() == Resource::DT_15TH_EDITION || e->_res.getDataType() == Resource::DT_20TH_EDITION) {
+		if (Script::_useRemasteredAudio) {
+			debug(DBG_INFO, "Using remastered audio");
+		} else {
+			debug(DBG_INFO, "Using original audio");
 		}
 	}
 	SystemStub *stub = SystemStub_SDL_create();

--- a/mixer.cpp
+++ b/mixer.cpp
@@ -143,12 +143,12 @@ struct Mixer_impl {
 		Mix_Volume(channel, volume * MIX_MAX_VOLUME / 63);
 	}
 
-	void playMusic(const char *path) {
+	void playMusic(const char *path, int loops = 0) {
 		stopMusic();
 		_music = Mix_LoadMUS(path);
 		if (_music) {
 			Mix_VolumeMusic(MIX_MAX_VOLUME / 2);
-			Mix_PlayMusic(_music, 0);
+			Mix_PlayMusic(_music, loops);
 		} else {
 			warning("Failed to load music '%s', %s", path, Mix_GetError());
 		}
@@ -247,10 +247,10 @@ void Mixer::setChannelVolume(uint8_t channel, uint8_t volume) {
 	}
 }
 
-void Mixer::playMusic(const char *path) {
-	debug(DBG_SND, "Mixer::playMusic(%s)", path);
+void Mixer::playMusic(const char *path, uint8_t loop) {
+	debug(DBG_SND, "Mixer::playMusic(%s, %d)", path, loop);
 	if (_impl) {
-		return _impl->playMusic(path);
+		return _impl->playMusic(path, (loop != 0) ? -1 : 0);
 	}
 }
 

--- a/mixer.h
+++ b/mixer.h
@@ -28,7 +28,7 @@ struct Mixer {
 	void playSoundAiff(uint8_t channel, const uint8_t *data, uint8_t volume);
 	void stopSound(uint8_t channel);
 	void setChannelVolume(uint8_t channel, uint8_t volume);
-	void playMusic(const char *path);
+	void playMusic(const char *path, uint8_t loop);
 	void stopMusic();
 	void playAifcMusic(const char *path, uint32_t offset);
 	void stopAifcMusic();

--- a/resource_nth.cpp
+++ b/resource_nth.cpp
@@ -5,6 +5,7 @@
 #include "pak.h"
 #include "resource_nth.h"
 #include "util.h"
+#include "script.h"
 
 static char *loadTextFile(File &f, const int size) {
 	char *buf = (char *)malloc(size + 1);
@@ -88,8 +89,11 @@ struct Resource15th: ResourceNth {
 
 	virtual uint8_t *loadWav(int num, uint8_t *dst, uint32_t *size) {
 		char name[32];
-		snprintf(name, sizeof(name), "rmsnd/file%03d.wav", num);
-		const PakEntry *e = _pak.find(name);
+		const PakEntry *e = 0;
+		if (Script::_useRemasteredAudio) {
+			snprintf(name, sizeof(name), "rmsnd/file%03d.wav", num);
+			e = _pak.find(name);
+		}
 		if (!e) {
 			snprintf(name, sizeof(name), "file%03db.wav", num);
 			e = _pak.find(name);
@@ -181,14 +185,14 @@ struct Resource15th: ResourceNth {
 		const char *path = 0;
 		switch (num) {
 		case 7:
-			if (_hasRemasteredMusic) {
+			if (_hasRemasteredMusic && Script::_useRemasteredAudio) {
 				path = "Music/AW/RmSnd/Intro2004.wav";
 			} else {
 				path = "Music/AW/Intro2004.wav";
 			}
 			break;
 		case 138:
-			if (_hasRemasteredMusic) {
+			if (_hasRemasteredMusic && Script::_useRemasteredAudio) {
 				path = "Music/AW/RmSnd/End2004.wav";
 			} else {
 				path = "Music/AW/End2004.wav";
@@ -376,6 +380,15 @@ struct Resource20th: ResourceNth {
 
 	virtual uint8_t *loadWav(int num, uint8_t *dst, uint32_t *size) {
 		char path[MAXPATHLEN];
+		if (!Script::_useRemasteredAudio) {
+			snprintf(path, sizeof(path), "%s/game/WGZ/original/file%03d.wgz", _dataPath, num);
+			struct stat s;
+			if (stat(path, &s) != 0) {
+				snprintf(path, sizeof(path), "%s/game/WGZ/original/file%03dB.wgz", _dataPath, num);
+			}
+			*size = 0;
+			return inflateGzip(path);
+		}
 		switch (num) {
 		case 81: {
 				const int r = 1 + rand() % 3;
@@ -486,7 +499,7 @@ struct Resource20th: ResourceNth {
 	}
 
 	virtual const char *getMusicName(int num) {
-		if (num >= 5000) {
+		if (num >= 5000 && Script::_useRemasteredAudio) {
 			snprintf(_musicName, sizeof(_musicName), "game/OGG/amb%d.ogg", num);
 			switch (num) {
 			case 5005:
@@ -502,11 +515,18 @@ struct Resource20th: ResourceNth {
 		} else {
 			switch (num) {
 			case 7:
-				strcpy(_musicName, "game/OGG/Intro_20th.ogg");
+				if (Script::_useRemasteredAudio) {
+					strcpy(_musicName, "game/OGG/Intro_20th.ogg");
+				} else {
+					strcpy(_musicName, "game/OGG/original/intro.ogg");
+				}
 				break;
 			case 138:
-				strcpy(_musicName, "game/OGG/Ending_15th.ogg");
-				break;
+				if (!Script::_useRemasteredAudio) {
+					strcpy(_musicName, "game/OGG/original/ending.ogg");
+					break;
+				}
+				/* fall-through */
 			default:
 				return 0;
 			}

--- a/script.h
+++ b/script.h
@@ -47,6 +47,7 @@ struct Script {
 	static const OpcodeStub _opTable[];
 	static const uint16_t _freqTable[];
 	static Difficulty _difficulty;
+	static bool _useRemasteredAudio;
 
 	Mixer *_mix;
 	Resource *_res;


### PR DESCRIPTION
This change adds a command-line option to select original or remastered audio (in 15th/20th Anniversary Edition) and these audio related fixes:
 - ambient music looping in 20th Anniversary Edition
 - using correct remastered ending music in 20th Anniversary Edition
 - using correct sound effects in intro in 20th Anniversary Edition
 - don't cut off music in 15th/20th Anniversary Edition and in Windows 3.1 version