### PR TITLE
Use sample rate specified by the script instead of .wav header value

### DIFF
--- a/script.cpp
+++ b/script.cpp
@@ -741,20 +741,16 @@ void Script::snd_playSound(uint16_t resNum, uint8_t freq, uint8_t vol, uint8_t c
 	if (vol > 63) {
 		vol = 63;
 	}
+	if (freq > 39) {
+		freq = 39;
+	}
 	switch (_res->getDataType()) {
-	case Resource::DT_15TH_EDITION: {
+	case Resource::DT_15TH_EDITION:
+	case Resource::DT_20TH_EDITION:
+	case Resource::DT_WIN31: {
 			uint8_t *buf = _res->loadWav(resNum);
 			if (buf) {
 				_mix->playSoundWav(channel & 3, buf, _freqTable[freq], vol, getWavLooping(resNum));
-			}
-		}
-		break;
-	case Resource::DT_20TH_EDITION:
-	case Resource::DT_WIN31: {
-			// ignore sample rate specified by the script, use .wav header value
-			uint8_t *buf = _res->loadWav(resNum);
-			if (buf) {
-				_mix->playSoundWav(channel & 3, buf, 0, vol, getWavLooping(resNum));
 			}
 		}
 		break;
@@ -771,7 +767,6 @@ void Script::snd_playSound(uint16_t resNum, uint8_t freq, uint8_t vol, uint8_t c
 	case Resource::DT_DOS: {
 			MemEntry *me = &_res->_memList[resNum];
 			if (me->status == Resource::STATUS_LOADED) {
-				assert(freq < 40);
 				_mix->playSoundRaw(channel & 3, me->bufPtr, _freqTable[freq], vol);
 			}
 		}


### PR DESCRIPTION
This change uses sample rate specified by the script to convert .wav files to correct frequency instead of using sample rate from the header value.

Also a question about function convertMono8 (in mixer.cpp):
If I understand correctly, the sound is first resampled to 11025Hz and then it's converted and resampled to 44100Hz. That might be OK if the original sample rate is lower than 11025Hz, but when it's higher then some audio data is lost, which lowers quality.
Why not resample it directly to 44100Hz and then just convert the format ?

And what about either a compile-time or run-time switch to either use higher quality/lower performance resampling (SDL_ConvertAudio) or the existing lower quality/higher performance resampling ? And also apply the switch to resampling .wav files.