### PR TITLE
Fix text in the intro in Win3.1 version

### DIFF
--- a/resource_win31.cpp
+++ b/resource_win31.cpp
@@ -301,7 +301,7 @@ void ResourceWin31::readStrings() {
 		if (num == 0xFFFF) {
 			break;
 		}
-		if (num < ARRAYSIZE(_stringsTable)) {
+		if (num < ARRAYSIZE(_stringsTable) && _stringsTable[num] == 0) {
 			_stringsTable[num] = (const char *)_textBuf + offset;
 		}
 		while (offset < len && _textBuf[offset++] != 0);


### PR DESCRIPTION
In the Win3.1 version there are some string with the same ID. With this change, the first string is used instead of the last.
The text in the intro which is fixed has ID 0x194.

I have a question about function preloadDat (in resource_nth.cpp). Is the functionality correct ? Where does it come from ?
The functions sets a file name which is later used in function loadDat instead of file name _FILE???.DAT_. But the original executable (20th edition) only uses files _FILE???.DAT_ and not the files in function preloadDat.
Some of the files don't have the same content (i.e. PRI2011.mac and FILE030.DAT) and there's at least one graphical glitch when using files from function preloadDat instead of _FILE???.DAT_ (using Linux version of 20th edition, original render and original audio) - look at Lester's hair in the picture.

![screenshot](https://user-images.githubusercontent.com/12173952/148804749-c616c96d-bbcf-419f-88ae-d50e1ce540bd.png)
