### PR TITLE
Fix software audio mixer for Amiga/Atari/DOS versions

### DIFF
--- a/mixer.cpp
+++ b/mixer.cpp
@@ -37,8 +37,8 @@ struct MixerChannel {
 	int _volume;
 
 	void init(const uint8_t *data, int freq, int volume, int mixingFreq) {
-		_data = data;
-		_pos.offset = 8 << Frac::BITS;
+		_data = data + 8;
+		_pos.offset = 0;
 		_pos.inc = (freq << Frac::BITS) / mixingFreq;
 
 		const int len = READ_BE_UINT16(data) * 2;

--- a/mixer.cpp
+++ b/mixer.cpp
@@ -51,11 +51,12 @@ struct MixerChannel {
 
 	void mix(int16_t &sample) {
 		if (_data) {
-			const uint32_t pos = _pos.getInt();
+			uint32_t pos = _pos.getInt();
 			_pos.offset += _pos.inc;
 			if (_loopLen != 0) {
 				if (pos >= _loopPos + _loopLen) {
-					_pos.offset = _loopPos << Frac::BITS;
+					pos = _loopPos;
+					_pos.offset = (_loopPos << Frac::BITS) + _pos.inc;
 				}
 			} else {
 				if (pos >= _len) {


### PR DESCRIPTION
This change fixes a problem where the last 8 bytes of a sample wouldn't be played, and the loop start position is also offset by 8 bytes.

A question related to the mixer:
The mixer mixes two channels to the left and two channels to the right, because the Amiga does it that way. But the DOS version doesn't do this (I think it's mono only) and I don't know how Atari does it. Wouldn't it be better to mix all four channels to both left and right (which I think sounds better) ?