### PR TITLE
Add a software audio mixer for Win3.1/15th/20th versions

### DIFF
--- a/engine.cpp
+++ b/engine.cpp
@@ -97,13 +97,13 @@ void Engine::setup(Language lang, int graphicsType, const char *scalerName, int 
 		_vid.setDefaultFont();
 	}
 	_script.init();
-	bool softwareMixer = false;
+	int softwareMixer = 0;
 	switch (_res.getDataType()) {
 	case Resource::DT_DOS:
 	case Resource::DT_AMIGA:
 	case Resource::DT_ATARI:
 	case Resource::DT_ATARI_DEMO:
-		softwareMixer = true;
+		softwareMixer = 1;
 		switch (lang) {
 		case LANG_FR:
 			_vid._stringsTable = Video::_stringsTableFr;
@@ -113,6 +113,11 @@ void Engine::setup(Language lang, int graphicsType, const char *scalerName, int 
 			_vid._stringsTable = Video::_stringsTableEng;
 			break;
 		}
+		break;
+	case Resource::DT_WIN31:
+	case Resource::DT_15TH_EDITION:
+	case Resource::DT_20TH_EDITION:
+		softwareMixer = 2;
 		break;
 	default:
 		break;

--- a/engine.cpp
+++ b/engine.cpp
@@ -97,13 +97,13 @@ void Engine::setup(Language lang, int graphicsType, const char *scalerName, int 
 		_vid.setDefaultFont();
 	}
 	_script.init();
-	int softwareMixer = 0;
+	MixerType mixerType = kMixerTypeRaw;
 	switch (_res.getDataType()) {
 	case Resource::DT_DOS:
 	case Resource::DT_AMIGA:
 	case Resource::DT_ATARI:
 	case Resource::DT_ATARI_DEMO:
-		softwareMixer = 1;
+		mixerType = kMixerTypeRaw;
 		switch (lang) {
 		case LANG_FR:
 			_vid._stringsTable = Video::_stringsTableFr;
@@ -117,12 +117,13 @@ void Engine::setup(Language lang, int graphicsType, const char *scalerName, int 
 	case Resource::DT_WIN31:
 	case Resource::DT_15TH_EDITION:
 	case Resource::DT_20TH_EDITION:
-		softwareMixer = 2;
+		mixerType = kMixerTypeWav;
 		break;
-	default:
+	case Resource::DT_3DO:
+		mixerType = kMixerTypeAiff;
 		break;
 	}
-	_mix.init(softwareMixer);
+	_mix.init(mixerType);
 #ifndef BYPASS_PROTECTION
 	switch (_res.getDataType()) {
 	case Resource::DT_DOS:

--- a/intern.h
+++ b/intern.h
@@ -148,7 +148,7 @@ struct Frac {
 	uint64_t offset;
 
 	void reset(int n, int d) {
-		inc = (n << BITS) / d;
+		inc = (((int64_t)n) << BITS) / d;
 		offset = 0;
 	}
 

--- a/mixer.cpp
+++ b/mixer.cpp
@@ -23,24 +23,12 @@ enum {
 static const bool kAmigaStereoChannels = false; // 0,3:left 1,2:right
 
 static int16_t u8toS16(int a) {
-	if (a <= 0) {
-		return -32768;
-	} else if (a >= 255) {
-		return 32767;
-	} else {
-		return ((a << 8) | a) - 32768;
-	}
+	return ((a << 8) | a) - 32768;
 }
 
 static int16_t s8toS16(int a) {
-	if (a <= -128) {
-		return -32768;
-	} else if (a >= 127) {
-		return 32767;
-	} else {
-		const uint8_t u8 = (a ^ 0x80);
-		return ((u8 << 8) | u8) - 32768;
-	}
+	const uint8_t u8 = (a ^ 0x80);
+	return ((u8 << 8) | u8) - 32768;
 }
 
 static int16_t mixS16(int sample1, int sample2) {

--- a/mixer.cpp
+++ b/mixer.cpp
@@ -204,7 +204,7 @@ struct Mixer_impl {
 	SfxPlayer *_sfx;
 	std::map<int, Mix_Chunk *> _preloads; // AIFF preloads (3DO)
 
-	void init(int softwareMixer) {
+	void init(MixerType mixerType) {
 		memset(_sounds, 0, sizeof(_sounds));
 		_music = 0;
 		memset(_channels, 0, sizeof(_channels));
@@ -217,12 +217,16 @@ struct Mixer_impl {
 		if (Mix_OpenAudio(kMixFreq, kMixFormat, kMixSoundChannels, kMixBufSize) < 0) {
 			warning("Mix_OpenAudio failed: %s", Mix_GetError());
 		}
-		if (softwareMixer == 1) {
+		switch (mixerType) {
+		case kMixerTypeRaw:
 			Mix_HookMusic(mixAudio, this);
-		} else if (softwareMixer == 2) {
+			break;
+		case kMixerTypeWav:
 			Mix_SetPostMix(mixAudioWav, this);
-		} else {
+			break;
+		case kMixerTypeAiff:
 			Mix_AllocateChannels(kMixChannels);
+			break;
 		}
 	}
 	void quit() {
@@ -406,9 +410,9 @@ Mixer::Mixer(SfxPlayer *sfx)
 	: _aifc(0), _sfx(sfx) {
 }
 
-void Mixer::init(int softwareMixer) {
+void Mixer::init(MixerType mixerType) {
 	_impl = new Mixer_impl();
-	_impl->init(softwareMixer);
+	_impl->init(mixerType);
 }
 
 void Mixer::quit() {

--- a/mixer.cpp
+++ b/mixer.cpp
@@ -22,13 +22,8 @@ enum {
 
 static const bool kAmigaStereoChannels = false; // 0,3:left 1,2:right
 
-static int16_t u8toS16(int a) {
+static int16_t toS16(int a) {
 	return ((a << 8) | a) - 32768;
-}
-
-static int16_t s8toS16(int a) {
-	const uint8_t u8 = (a ^ 0x80);
-	return ((u8 << 8) | u8) - 32768;
 }
 
 static int16_t mixS16(int sample1, int sample2) {
@@ -81,7 +76,7 @@ struct MixerChannel {
 					return;
 				}
 			}
-			sample = mixS16(sample, s8toS16(((int8_t)_data[pos]) * _volume / 64));
+			sample = mixS16(sample, toS16(_data[pos] ^ 0x80) * _volume / 64);
 		}
 	}
 
@@ -104,7 +99,7 @@ struct MixerChannel {
 			}
 			int valueL;
 			if (bits == 8) { // U8
-				valueL = u8toS16(_data[pos]) * _volume / 64;
+				valueL = toS16(_data[pos]) * _volume / 64;
 			} else { // S16
 				valueL = ((int16_t)READ_LE_UINT16(&_data[pos * sizeof(int16_t)])) * _volume / 64;
 			}
@@ -116,7 +111,7 @@ struct MixerChannel {
 				valueR = valueL;
 			} else {
 				if (bits == 8) { // U8
-					valueR = u8toS16(_data[pos + 1]) * _volume / 64;
+					valueR = toS16(_data[pos + 1]) * _volume / 64;
 				} else { // S16
 					valueR = ((int16_t)READ_LE_UINT16(&_data[(pos + 1) * sizeof(int16_t)])) * _volume / 64;
 				}

--- a/mixer.cpp
+++ b/mixer.cpp
@@ -58,8 +58,7 @@ struct MixerChannel {
 
 	void initWav(const uint8_t *data, int freq, int volume, int mixingFreq, int len, bool bits16, bool stereo, bool loop) {
 		_data = data;
-		_pos.inc = (((int64_t)freq) << Frac::BITS) / mixingFreq;
-		_pos.offset = 0;
+		_pos.reset(freq, mixingFreq);
 
 		_len = len;
 		_loopLen = loop ? len : 0;

--- a/mixer.cpp
+++ b/mixer.cpp
@@ -22,7 +22,17 @@ enum {
 
 static const bool kAmigaStereoChannels = false; // 0,3:left 1,2:right
 
-static int16_t toS16(int a) {
+static int16_t u8toS16(int a) {
+	if (a <= 0) {
+		return -32768;
+	} else if (a >= 255) {
+		return 32767;
+	} else {
+		return ((a << 8) | a) - 32768;
+	}
+}
+
+static int16_t s8toS16(int a) {
 	if (a <= -128) {
 		return -32768;
 	} else if (a >= 127) {
@@ -84,7 +94,7 @@ struct MixerChannel {
 					return;
 				}
 			}
-			sample = mixS16(sample, toS16(((int8_t)_data[pos]) * _volume / 64));
+			sample = mixS16(sample, s8toS16(((int8_t)_data[pos]) * _volume / 64));
 		}
 	}
 
@@ -107,7 +117,7 @@ struct MixerChannel {
 			}
 			int valueL;
 			if (bits == 8) { // U8
-				valueL = toS16(_data[pos] - 128) * _volume / 64;
+				valueL = u8toS16(_data[pos]) * _volume / 64;
 			} else { // S16
 				valueL = ((int16_t)READ_LE_UINT16(&_data[pos * sizeof(int16_t)])) * _volume / 64;
 			}
@@ -118,7 +128,7 @@ struct MixerChannel {
 				valueR = valueL;
 			} else {
 				if (bits == 8) { // U8
-					valueR = toS16(_data[pos + 1] - 128) * _volume / 64;
+					valueR = u8toS16(_data[pos + 1]) * _volume / 64;
 				} else { // S16
 					valueR = ((int16_t)READ_LE_UINT16(&_data[(pos + 1) * sizeof(int16_t)])) * _volume / 64;
 				}

--- a/mixer.h
+++ b/mixer.h
@@ -19,7 +19,7 @@ struct Mixer {
 	Mixer_impl *_impl;
 
 	Mixer(SfxPlayer *sfx);
-	void init(bool softwareMixer);
+	void init(int softwareMixer);
 	void quit();
 	void update();
 

--- a/mixer.h
+++ b/mixer.h
@@ -13,13 +13,19 @@ struct AifcPlayer;
 struct SfxPlayer;
 struct Mixer_impl;
 
+enum MixerType {
+	kMixerTypeRaw,
+	kMixerTypeWav,
+	kMixerTypeAiff
+};
+
 struct Mixer {
 	AifcPlayer *_aifc;
 	SfxPlayer *_sfx;
 	Mixer_impl *_impl;
 
 	Mixer(SfxPlayer *sfx);
-	void init(int softwareMixer);
+	void init(MixerType mixerType);
 	void quit();
 	void update();
 


### PR DESCRIPTION
This adds a software mixer for .wav files, so they don't need to be converted every time they are played. I successfully tested the function `loadWav` with every .wav file in Win3.1/15th/20th versions.

Also a question:
In function playMusic, why is the music volume set to 50% (`Mix_VolumeMusic(MIX_MAX_VOLUME / 2);`) ? It sounds really quiet, especially the ambient music.